### PR TITLE
Fix deletion idempotency for item removal in Sprint 1

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -316,9 +316,13 @@ def delete_item_from_shopcart(shopcart_id, item_id):
     if item:
         # Delete the item if it exists
         item.delete()
-        app.logger.info("Item with id %s deleted from Shopcart %s", item_id, shopcart_id)
+        app.logger.info(
+            "Item with id %s deleted from Shopcart %s", item_id, shopcart_id
+        )
     else:
-        app.logger.info("Item with id %s not found in Shopcart %s", item_id, shopcart_id)
+        app.logger.info(
+            "Item with id %s not found in Shopcart %s", item_id, shopcart_id
+        )
 
     return {}, status.HTTP_204_NO_CONTENT
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -313,16 +313,13 @@ def delete_item_from_shopcart(shopcart_id, item_id):
 
     # Find the item by item_id within the shopcart
     item = Item.query.filter_by(id=item_id, shopcart_id=shopcart_id).first()
-    if not item:
-        abort(
-            status.HTTP_404_NOT_FOUND,
-            f"Item with id '{item_id}' in Shopcart '{shopcart_id}' was not found.",
-        )
+    if item:
+        # Delete the item if it exists
+        item.delete()
+        app.logger.info("Item with id %s deleted from Shopcart %s", item_id, shopcart_id)
+    else:
+        app.logger.info("Item with id %s not found in Shopcart %s", item_id, shopcart_id)
 
-    # Delete the item
-    item.delete()
-
-    app.logger.info("Item with id %s deleted from Shopcart %s", item_id, shopcart_id)
     return {}, status.HTTP_204_NO_CONTENT
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -410,7 +410,7 @@ class TestShopcartService(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_delete_item_not_found(self):
-        """It should return 404 when trying to delete an item that does not exist"""
+        """It should return 204 when trying to delete an item that does not exist"""
         # Create a shopcart
         shopcart = ShopcartFactory()
         resp = self.client.post(BASE_URL, json=shopcart.serialize())
@@ -422,8 +422,9 @@ class TestShopcartService(TestCase):
             f"{BASE_URL}/{new_shopcart['id']}/items/0"
         )  # ID 0 doesn't exist
         self.assertEqual(
-            resp.status_code, status.HTTP_404_NOT_FOUND
-        )  # Expect 404 for non-existent item
+            resp.status_code, status.HTTP_204_NO_CONTENT
+        )  # Expect 204 for non-existent item
+
 
     # ----------------------------------------------------------
     # TEST LIST

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -425,7 +425,6 @@ class TestShopcartService(TestCase):
             resp.status_code, status.HTTP_204_NO_CONTENT
         )  # Expect 204 for non-existent item
 
-
     # ----------------------------------------------------------
     # TEST LIST
     # ----------------------------------------------------------


### PR DESCRIPTION
This PR fixes the issue of item deletion idempotency in Sprint 1. The deletion endpoint now returns 204_NO_CONTENT even when an item is not found, ensuring idempotency.

Changes:
- Modified delete_item_from_shopcart to return 204_NO_CONTENT when the item is not found.
- Updated the corresponding test case (test_delete_item_not_found) to reflect this behavior.