### PR TITLE
CodeCov YAML

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 90%  # Sets patch coverage threshold at 90%
+    project:
+      default:
+        target: 95%  # Optional: sets project-wide coverage target at 95%


### PR DESCRIPTION
https://docs.codecov.com/docs/codecov-yaml#repository-yaml
CodeCov configured to fail only if 'patch' coverage drops below 90% and project-wide coverage below 95%.
The rationale is: It's fine if the coverage of the PR is a little lower than 95%, As long as the project-wide coverage doesn't dip below 95%